### PR TITLE
Fix issue with Invoke-Exe

### DIFF
--- a/content/settings.ps1
+++ b/content/settings.ps1
@@ -19,7 +19,9 @@ Function Invoke-Exe {
     )
 
     Write-Host "> $Executable $Arguments"
-    $rc = Start-Process -FilePath $Executable -ArgumentList $Arguments -NoNewWindow -Wait -Passthru
+    $rc = Start-Process -FilePath $Executable -ArgumentList $Arguments -NoNewWindow -Passthru
+    $rc.Handle # to initialize handle according to https://stackoverflow.com/a/23797762/2684760
+    $rc.WaitForExit()
     if (-Not $ValidExitCodes.Contains($rc.ExitCode)) {
         throw "'$Executable $Arguments' failed with exit code $($rc.ExitCode), valid exit codes: $ValidExitCodes"
     }


### PR DESCRIPTION
Sometimes MSBuild may create long-living daemon processes that will outlive the build. `Start-Process -Wait` will wait for all of them to exit, and that's not the desirable behavior.

Instead of that, let's invoke `WaitForExit()` manually on the returned `Process` object. Although, due to the issue described [here], we should also call `Handle` property before calling `WaitForExit`.

[here]: https://stackoverflow.com/a/23797762/2684760

Closes #1.