### PR TITLE
Ensure vswhere does not include MSSQL

### DIFF
--- a/content/build.gradle.kts
+++ b/content/build.gradle.kts
@@ -67,7 +67,7 @@ val setBuildTool by tasks.registering {
             val stdout = ByteArrayOutputStream()
             exec {
                 executable("${rootDir}\\tools\\vswhere.exe")
-                args("-latest", "-property", "installationPath", "-products", "*")
+                args("-latest", "-property", "installationPath")
                 standardOutput = stdout
                 workingDir(rootDir)
             }


### PR DESCRIPTION
With the template I was not able to build/publish a plugin, as it had issue with locating msbuild. I currently have multiple tools installed through the Visual Studio Installer, this causes non VisualStudio applications to be returned through vswhere.

<img width="1309" height="688" alt="image" src="https://github.com/user-attachments/assets/59a32d25-4de7-48cd-99cd-8f730cfcf851" />

As per the help page of vswhere.exe

<img width="1385" height="74" alt="image" src="https://github.com/user-attachments/assets/cded9f75-91a8-4bae-bfda-a5d04f71ab6c" />

Removing the wild card flag causes only Visual Studio installation paths to be returned. Here is a before an after:

<img width="1095" height="64" alt="image" src="https://github.com/user-attachments/assets/bcd4a7a4-66c3-4083-9f49-d63e4589f2ae" />
<img width="945" height="67" alt="image" src="https://github.com/user-attachments/assets/4a4c9bd1-9b3d-409e-a53c-5e677b00992c" />

So at least for me, the following change allowed my builds to succeed. 


